### PR TITLE
[DNM] Added support for custom contentViewFactory

### DIFF
--- a/src/default-permalink-content-renderer.js
+++ b/src/default-permalink-content-renderer.js
@@ -6,9 +6,10 @@ var styles = require('css!./css/styles.css');
 var sdkStyles = require('css!streamhub-sdk/css/style.css');
 var packageAttribute = require('./package-attribute');
 
-var defaultPermalinkContentHandler = function (content) {
+var defaultPermalinkContentHandler = function (content, opts) {
+    opts = opts || {};
     //Get the view for the content
-    var cvf = permalinkViewFactory(),
+    var cvf = permalinkViewFactory({ baseFactory: opts.contentViewFactory }),
         contentView = cvf.createContentView(content);
 
     //Show the contentView in a modal

--- a/src/default-permalink-content-renderer.js
+++ b/src/default-permalink-content-renderer.js
@@ -9,7 +9,7 @@ var packageAttribute = require('./package-attribute');
 var defaultPermalinkContentHandler = function (content, opts) {
     opts = opts || {};
     //Get the view for the content
-    var cvf = permalinkViewFactory({ baseFactory: opts.contentViewFactory }),
+    var cvf = opts.contentViewFactory || permalinkViewFactory(),
         contentView = cvf.createContentView(content);
 
     //Show the contentView in a modal

--- a/src/handlers/content.js
+++ b/src/handlers/content.js
@@ -11,7 +11,7 @@ var fetchContent = require('streamhub-sdk/content/fetch-content');
  * @param contentInfo.contentId {!string} ID for the content
  * @param [contentInfo.environment] {string=} For environments other than production
  */
-var contentHandler = function (permalink, key, contentInfo, callback) {
+var contentHandler = function (permalink, key, contentInfo, callback, contentViewFactory) {
     var contentId = contentInfo.contentId,
         collectionId = contentInfo.collectionId,
         environment = contentInfo.environment,
@@ -39,7 +39,7 @@ var contentHandler = function (permalink, key, contentInfo, callback) {
         }
 
         permalink.set('content-options', opts);
-        permalink.default(key, require('streamhub-permalink/default-permalink-content-renderer'));
+        permalink.default(key, require('streamhub-permalink/default-permalink-content-renderer'), permalink, [{ contentViewFactory: contentViewFactory }]);
         permalink.set(key, content);
         callback();
     }

--- a/src/permalink.js
+++ b/src/permalink.js
@@ -21,7 +21,8 @@ var bind = require('mout/function/bind');
  * @constructor
  * @extends {EventEmitter}
  */
-var Permalink = function () {
+var Permalink = function (opts) {
+    opts = opts || {};
     EventEmitter.call(this);
     var msgEvent = window.addEventListener ? 'message' : 'onmessage';
     var addEvent = window.addEventListener || window.attachEvent;
@@ -31,7 +32,7 @@ var Permalink = function () {
     if (content) {
         addEvent(msgEvent, bind(this.onPostMessage, this), false);
         //Load the code to parse, fetch, and display content
-        require('streamhub-permalink/handlers/content')(this, enums.KEYS.CONTENT, content, bind(this.sendRegistration, this));
+        require('streamhub-permalink/handlers/content')(this, enums.KEYS.CONTENT, content, bind(this.sendRegistration, this), opts.contentViewFactory);
     }
 };
 inherits(Permalink, EventEmitter);


### PR DESCRIPTION
I have a RequireJS project that includes several Livefyre SDK applications from source, not using the Livefyre.js loader for anything except Auth and fyre.conv.  I disabled the modal from Livefyre.js's automatic spawning of streamhub-permalink so that I can include streamhub-permalink in my source and customize its behavior.  All I really want to do at this point is use a custom ContentView in the permalink modal.

I saw the 'opts.baseFactory' in permalink-view-factory, but no way to actually pass in that option, so that's what I added here.  So in my app I can do:

``` javascript
   new Permalink({
        contentViewFactory: new MyContentViewFactory()
    });
```
